### PR TITLE
Make kafka listeners great again

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8
 
 # We'll add netcat cos it's a really useful
 # network troubleshooting tool
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get install -y netcat
 
 # Install the Confluent Kafka python library
-RUN pip install confluent_kafka
+RUN pip install -U pip confluent_kafka
 
 # Add our script
 ADD python_kafka_test_client.py /

--- a/python/docker-compose.yml
+++ b/python/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 version: '3.5'
 
-networks: 
+networks:
   rmoff_kafka:
     name: rmoff_kafka
 
@@ -9,7 +9,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.0
     container_name: zookeeper
-    networks: 
+    networks:
       - rmoff_kafka
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
@@ -17,9 +17,9 @@ services:
   broker:
     image: confluentinc/cp-kafka:5.5.0
     container_name: broker
-    ports: 
+    ports:
       - "19092:19092"
-    networks: 
+    networks:
       - rmoff_kafka
     depends_on:
       - zookeeper
@@ -31,18 +31,18 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   client:
-    image: python_kafka_test_client
+    build:
+      dockerfile: Dockerfile
     container_name: python_kafka_test_client
-    depends_on: 
+    depends_on:
       - broker
-    networks: 
+    networks:
       - rmoff_kafka
-    entrypoint: 
-      - bash 
-      - -c 
+    entrypoint:
+      - bash
+      - -c
       - |
         echo 'Giving Kafka a bit of time to start up…'
         sleep 30
         # Run the client code
         python /python_kafka_test_client.py broker:9092
-        

--- a/python/docker-compose_initial.yml
+++ b/python/docker-compose_initial.yml
@@ -1,7 +1,7 @@
 ---
 version: '3.5'
 
-networks: 
+networks:
   rmoff_kafka:
     name: rmoff_kafka
 
@@ -9,7 +9,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.0
     container_name: zookeeper
-    networks: 
+    networks:
       - rmoff_kafka
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
@@ -17,7 +17,7 @@ services:
   broker:
     image: confluentinc/cp-kafka:5.5.0
     container_name: broker
-    networks: 
+    networks:
       - rmoff_kafka
     depends_on:
       - zookeeper
@@ -28,18 +28,18 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   client:
-    image: python_kafka_test_client
+    build:
+      dockerfile: Dockerfile
     container_name: python_kafka_test_client
-    depends_on: 
+    depends_on:
       - broker
-    networks: 
+    networks:
       - rmoff_kafka
-    entrypoint: 
-      - bash 
-      - -c 
+    entrypoint:
+      - bash
+      - -c
       - |
         echo 'Giving Kafka a bit of time to start up…'
         sleep 30
         # Run the client code
         python /python_kafka_test_client.py broker:9092
-        


### PR DESCRIPTION
Two fixes in this Pull Request both required to ensure this works out of the box.

## This will ensure it builds as the compose file is started.

Update python/Dockerfile to use python3.8

Build was failing with python3.

Latest version of pip ensures deps are installed much faster.

## Fix python/docker-compose*.yml

python/docker-compose*.yml were failing with

```
Error response from daemon: pull access denied for python_kafka_test_client,
repository does not exist or
may require 'docker login': denied: requested access to the resource is denied
```

-------

FWIW: I'm not sure of the point of `python/docker-compose_initial.yml` - Unless we need it could we delete it?